### PR TITLE
Hi there, I'm Jules! I've made some improvements to how ffmpeg VAAPI …

### DIFF
--- a/app/Services/HlsStreamService.php
+++ b/app/Services/HlsStreamService.php
@@ -143,10 +143,14 @@ class HlsStreamService
                 
                 if (!empty($vaapiFilterFromSettings)) {
                     $videoFilterArgs = "-vf '" . trim($vaapiFilterFromSettings, "'") . "' ";
+                } elseif ($vaapiEnabled) { // Check if VAAPI is the selected hardware_acceleration_method
+                    // If VAAPI is the method and the user hasn't specified a filter, apply a default.
+                    $videoFilterArgs = "-vf 'scale_vaapi=format=nv12' "; 
                 } else {
-                    $videoFilterArgs = ""; // No default -vf filter
+                    // If VAAPI is not the selected method (e.g., it's 'none' or 'qsv') 
+                    // and no specific VAAPI filter was set, then no VAAPI-related -vf should be added.
+                    $videoFilterArgs = ""; 
                 }
-                // If $vaapiFilterFromSettings is empty, no -vf is added here for VA-API.
                 // FFmpeg will handle conversions if possible, or fail if direct path isn't supported.
 
             } elseif ($qsvEnabled || $isQsvCodec) {


### PR DESCRIPTION
…handles video and its failover logic.

This update should fix some issues with ffmpeg VAAPI transcoding errors and make the stream failover mechanism more robust.

Here's what I did:

1.  **Corrected VAAPI Parameter Application:**
    *   I've ensured that both direct TS/MP4 streams and HLS streams consistently use your `hardware_acceleration_method` setting from General Settings.
    *   If you've selected VAAPI and left the `ffmpeg_vaapi_video_filter` setting empty, I'll now apply a default filter (`scale_vaapi=format=nv12`). This should resolve the "Impossible to convert between the formats" ffmpeg error by making sure the video frames are in a VAAPI-compatible format before they reach the hardware encoder.
    *   I've removed a local setting for enabling ffmpeg VAAPI and will now rely on the global `hardware_acceleration_method`.

2.  **Improved Failover Source Selection:**
    *   I've implemented a short-term (5-minute) cache for "bad sources."
    *   If a source fails initial checks or during stream startup, its ID will be added to this cache.
    *   If you try to use this source again (for either TS/MP4 or HLS) within the cache duration, I'll skip it immediately. This prevents repeated attempts on sources I know are having trouble.
    *   This applies to both client-initiated retries and my internal logic for trying the next available source.

3.  **Enhanced Logging:**
    *   I've added more detailed logging of video stream characteristics (like codec, pixel format, resolution, profile, and level) after a successful pre-check. This will help in diagnosing any future transcoding or stream compatibility issues you might encounter.

These changes should lead to more reliable VAAPI transcoding and more resilient stream failovers by avoiding problematic sources for a while.