### PR TITLE
fix: Active streams count for HLS

### DIFF
--- a/config/dev.php
+++ b/config/dev.php
@@ -2,7 +2,7 @@
 
 return [
     'author' => 'Shaun Parkison',
-    'version' => '0.6.5',
+    'version' => '0.6.6',
     'repo' => 'sparkison/m3u-editor',
     'docs_url' => 'https://sparkison.github.io/m3u-editor-docs',
     'donate' => 'https://buymeacoffee.com/shparkison',


### PR DESCRIPTION
When streaming via HLS the active streams count was being decremented twice. Fix to ensure it's only decremented once whether stopped naturally and pruned, or via failover