### PR TITLE
Fix: Correct SQL typo and Carbon to int conversion error

### DIFF
--- a/app/Services/SharedStreamService.php
+++ b/app/Services/SharedStreamService.php
@@ -2059,7 +2059,7 @@ class SharedStreamService
                 } else {
                     // Clean up disconnected clients for active streams
                     $inactiveClients = SharedStreamClient::where('stream_id', $streamKey)
-                        ->where('last_activity', '<', $inactiveThreshold)
+                        ->where('last_activity_at', '<', $inactiveThreshold)
                         ->get();
 
                     foreach ($inactiveClients as $client) {

--- a/app/Services/StreamMonitorService.php
+++ b/app/Services/StreamMonitorService.php
@@ -584,8 +584,8 @@ class StreamMonitorService
             ];
 
             if (!empty($stream)) {
-                $health['last_activity'] = (int)($stream->last_client_activity ?? 0);
-                $health['uptime'] = time() - (int)($stream->started_at ?? 0);
+                $health['last_activity'] = $stream->last_client_activity ? $stream->last_client_activity->getTimestamp() : 0;
+                $health['uptime'] = $stream->started_at ? time() - $stream->started_at->getTimestamp() : 0;
 
                 // Check if process is running
                 $health['process_running'] = $stream->isProcessRunning();


### PR DESCRIPTION
- I corrected a typo in `SharedStreamService` where `last_activity` was used instead of `last_activity_at` in a query, causing an 'undefined column' SQL error.
- I modified `StreamMonitorService` to correctly convert Carbon datetime objects to Unix timestamps using `getTimestamp()` before attempting to cast them to integers or use them in integer arithmetic. This resolves the 'Object of class Illuminate\Support\Carbon could not be converted to int' error.