### PR TITLE
I've corrected stream monitoring and cleanup errors, and tuned FFmpeg.

### DIFF
--- a/app/Services/SharedStreamService.php
+++ b/app/Services/SharedStreamService.php
@@ -740,7 +740,8 @@ class SharedStreamService
         // Better error handling and more robust connection options
         $cmd .= '-err_detect ignore_err -ignore_unknown ';
         $cmd .= '-fflags +nobuffer+igndts -flags low_delay ';
-        $cmd .= '-analyzeduration 1M -probesize 1M -max_delay 500000 ';
+        // Increased analyzeduration and probesize to potentially help with SPS/PPS detection
+        $cmd .= '-analyzeduration 2M -probesize 2M -max_delay 500000 ';
 
         // HTTP options (simplified to match working approach)
         $cmd .= "-user_agent " . escapeshellarg($userAgent) . " -referer " . escapeshellarg("MyComputer") . " ";
@@ -2059,7 +2060,7 @@ class SharedStreamService
                 } else {
                     // Clean up disconnected clients for active streams
                     $inactiveClients = SharedStreamClient::where('stream_id', $streamKey)
-                        ->where('last_activity', '<', $inactiveThreshold)
+                        ->where('last_activity_at', '<', $inactiveThreshold)
                         ->get();
 
                     foreach ($inactiveClients as $client) {

--- a/app/Services/StreamMonitorService.php
+++ b/app/Services/StreamMonitorService.php
@@ -584,8 +584,12 @@ class StreamMonitorService
             ];
 
             if (!empty($stream)) {
-                $health['last_activity'] = (int)($stream->last_client_activity ?? 0);
-                $health['uptime'] = time() - (int)($stream->started_at ?? 0);
+                // Ensure last_client_activity and started_at are converted to timestamps if they are Carbon objects
+                $lastClientActivityTimestamp = $stream->last_client_activity ? ($stream->last_client_activity instanceof \Illuminate\Support\Carbon ? $stream->last_client_activity->timestamp : (int)$stream->last_client_activity) : 0;
+                $startedAtTimestamp = $stream->started_at ? ($stream->started_at instanceof \Illuminate\Support\Carbon ? $stream->started_at->timestamp : (int)$stream->started_at) : 0;
+
+                $health['last_activity'] = $lastClientActivityTimestamp;
+                $health['uptime'] = time() - $startedAtTimestamp;
 
                 // Check if process is running
                 $health['process_running'] = $stream->isProcessRunning();


### PR DESCRIPTION
- I fixed a Carbon to integer conversion error in StreamMonitorService by ensuring proper timestamp conversion.
- I corrected an SQL query in SharedStreamService to use `last_activity_at` instead of `last_activity` during stream client cleanup.
- I increased FFmpeg `analyzeduration` and `probesize` to 2M to potentially improve handling of streams with delayed SPS/PPS data.