### PR TITLE
feat: Tweak failover logic to use your defined playlist order

### DIFF
--- a/app/Filament/Resources/ChannelResource.php
+++ b/app/Filament/Resources/ChannelResource.php
@@ -624,7 +624,7 @@ class ChannelResource extends Resource
                     ])
                     ->action(function (Collection $records, array $data): void {
                         app('Illuminate\Contracts\Bus\Dispatcher')
-                            ->dispatch(new \App\Jobs\MergeChannels($records, auth()->user(), $data['playlist_id'] ?? null));
+                            ->dispatch(new \App\Jobs\MergeChannels($records->pluck('id'), auth()->user(), $data['playlist_id'] ?? null));
                     })->after(function () {
                         Notification::make()
                             ->success()

--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -22,7 +22,7 @@ class MergeChannels implements ShouldQueue
     /**
      * Create a new job instance.
      */
-    public function __construct(public Collection $channels, $user, $playlistId = null)
+    public function __construct(public Collection $channelIds, $user, $playlistId = null)
     {
         $this->user = $user;
         $this->playlistId = $playlistId;
@@ -34,8 +34,9 @@ class MergeChannels implements ShouldQueue
     public function handle(): void
     {
         $processed = 0;
+        $channels = Channel::whereIn('id', $this->channelIds)->get();
         // Filter out channels where the stream ID is empty
-        $filteredChannels = $this->channels->filter(function ($channel) {
+        $filteredChannels = $channels->filter(function ($channel) {
             return !empty($channel->stream_id_custom) || !empty($channel->stream_id);
         });
 


### PR DESCRIPTION
This commit modifies the channel merging logic to use your defined playlist order instead of stream resolution.

- The `ChannelResource` bulk action for merging channels now includes a select field for you to choose a "Primary Playlist".
- The `MergeChannels` job has been updated to use the selected primary playlist to determine the master channel, removing the previous resolution-based logic.
- A new test case has been added to `MergeChannelsTest` to verify the new behavior.
- The "Preferred Playlist" dropdown now shows all of your playlists.
- The `MergeChannels` job now accepts an array of channel IDs to avoid memory issues in the browser.