### PR TITLE
Fix: Merge all channels with failovers

### DIFF
--- a/app/Jobs/MergeChannels.php
+++ b/app/Jobs/MergeChannels.php
@@ -40,22 +40,22 @@ class MergeChannels implements ShouldQueue
                 $query->whereNotNull('stream_id_custom')->orWhereNotNull('stream_id');
             })->cursor();
 
-        // Get the failover channels from the specified playlists
-        $failoverChannels = Channel::whereIn('playlist_id', $this->playlists)
-            ->where('playlist_id', '!=', $this->playlistId) // Exclude primary playlist channels
-            ->where(function ($query) {
-                $query->whereNotNull('stream_id_custom')->orWhereNotNull('stream_id');
-            });
-
         // Loop through primary channels and assign any matching failover channels
         foreach ($primaryChannels as $channel) {
+            // Get the failover channels from the specified playlists
+            $failoverChannels = Channel::whereIn('playlist_id', $this->playlists)
+                ->where('playlist_id', '!=', $this->playlistId) // Exclude primary playlist channels
+                ->where(function ($query) {
+                    $query->whereNotNull('stream_id_custom')->orWhereNotNull('stream_id');
+                });
+
             // Skip if channel has no stream ID to match against
             if (!$channel->stream_id_custom && !$channel->stream_id) {
                 continue;
             }
 
             // Check if any of the failovers have the same stream ID
-            $matchingFailovers = $failoverChannels->clone() // make a copy of the query
+            $matchingFailovers = $failoverChannels
                 ->where(function ($query) use ($channel) {
                     if ($channel->stream_id_custom) {
                         $query->where('stream_id_custom', $channel->stream_id_custom);


### PR DESCRIPTION
The original code was only merging the first channel with failovers. This was because the `$failoverChannels` query was only being executed once, and the same result was being used for all primary channels.

This commit fixes the issue by moving the `$failoverChannels` query inside the `foreach` loop, so that it's re-evaluated for each primary channel.